### PR TITLE
Remove single quote as a possible string block

### DIFF
--- a/syntaxes/athena.json
+++ b/syntaxes/athena.json
@@ -44,7 +44,7 @@
 			"name": "comment.block.athena"
 		},
 		{
-			"match": "([\"'])(?:(?=(\\\\?))\\2.)*?\\1",
+			"match": "([\"])(?:(?=(\\\\?))\\2.)*?\\1",
 			"name": "string.block.athena"
 		},
 		{


### PR DESCRIPTION
I don't think athena lets you use a single quote `'` as a string token.
This screws up statements that use multiple instance variables, like below:

```
	if (rand(50) == 0 || 'second_commander == 'force_spawn) {// can re-spawn
		'second_commander = 'force_spawn + 1;
```
It currently looks like this:
![image](https://user-images.githubusercontent.com/6844975/87623326-01960300-c6da-11ea-9893-115034ed7be8.png)
